### PR TITLE
Use persistent names for config files

### DIFF
--- a/src/acl.py
+++ b/src/acl.py
@@ -40,12 +40,13 @@ class ACL:
             methods = self._default_allowed_methods if 'Methods' not in acl else acl['Methods']
             addresses = ['0.0.0.0/0'] if 'Addresses' not in acl else acl['Addresses']
             
-            random_name = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(CONST_CONFIG_FILENAME_SIZE))
-
+            file_name = '+'.join([acl['Access']] + [acl['Path']] + methods + addresses)
+            file_name = '_'.join(re.split('[^+.\w]', file_name))
+            
             config = self._template.render(allow=access, path=path, allowed_methods=methods, exact=True, compare=('regex' if '*' in path else 'exact'), addresses=addresses)
             
             # create configs
-            with open('/etc/nginx/conf.d/{}.conf'.format(random_name), 'w+') as f:
+            with open('/etc/nginx/conf.d/{}.conf'.format(file_name), 'w+') as f:
                 f.write(config)
 
 


### PR DESCRIPTION
There is a problem when you stop and start the container again, nginx will complain that there is duplicate config for any path you have configured. This causes the container to die immediately. It is due to the random naming of nginx config files that get included after templating the acls.

This patch changes the file names to be generated with a reasonable name based on the rules in each acl so the files will be overwritten on start up. Sherpa should probably have a handler to remove them on shut down so rules that have been deleted from sherpa's acls no longer take effect.